### PR TITLE
Add linux-bluetooth mailing list to Reply-To

### DIFF
--- a/run-ci.py
+++ b/run-ci.py
@@ -189,6 +189,8 @@ def compose_email(test_name, test_result, title, submitter, msgid):
     email_cfg = config['email']
     sender = email_cfg['user']
 
+    add_reply_to = False
+
     receivers = []
     if 'only-maintainers' in email_cfg and email_cfg['only-maintainers'] == 'yes':
         # Send only to the addresses in the 'maintainers'
@@ -199,11 +201,18 @@ def compose_email(test_name, test_result, title, submitter, msgid):
         receivers.append(email_cfg['default-to'])
         receivers.append(submitter)
 
+        add_reply_to = True
+
     # Create message
     msg = MIMEMultipart()
     msg['From'] = sender
     msg['To'] = ", ".join(receivers)
     msg['Subject'] = "RE: " + title
+
+    # In case to use default-to address, set Reply-To to mailing list in case
+    # submitter reply to the result email.
+    if add_reply_to:
+        msg['Reply-To'] = email_cfg['default-to']
 
     # Message Header
     msg.add_header('In-Reply-To', msgid)


### PR DESCRIPTION
This patch adds the linux-bluetooth mailing list address in "Reply-To"
field in case the submitter reply the result email to mailing list.
If not, the submitter will reply to the bot email address which no one
is monitoring.