### PR TITLE
Disable midi for workaround

### DIFF
--- a/run-ci.py
+++ b/run-ci.py
@@ -443,6 +443,7 @@ class CheckBuild(CiBase):
         # bootstrap-configure
         (ret, stdout, stderr) = run_cmd("./bootstrap-configure",
                                         "--enable-external-ell",
+                                        "--disable-midi",
                                         cwd=src_dir)
         if ret:
             self.add_failure(stderr)


### PR DESCRIPTION
There is an issue with test-midi which fails the test once in a while.
Until the issue is resolved, disable the midi to prevent the false
error.