### PR TITLE
Fix bold format in github comment

### DIFF
--- a/run-ci.py
+++ b/run-ci.py
@@ -106,7 +106,7 @@ GITHUB_COMMENT = '''**{display_name}**
 Test ID: {name}
 Desc: {desc}
 Duration: {elapsed:.2f} seconds
-**Result: {status:<25}**
+**Result: {status}**
 
 
 '''


### PR DESCRIPTION
This patch fixes the bold format is not properly showing in the github
comment due to the leading whitespace.