### PR TITLE
Remove unnecessary configuration - makedist

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -70,13 +70,6 @@ enable = yes
 
 
 ;
-; make dist options
-;
-[makedist]
-; Enable makedist run. Default is 'yes' if it is not defined
-enable = yes
-
-;
 ; make distcheck options
 ;
 [makedistcheck]


### PR DESCRIPTION
Makedist option is no longer needed and delete the configuration from
the config.ini.