### PR TITLE
gitlint: Add a rule to ignore the 2nd line space

### DIFF
--- a/gitlint
+++ b/gitlint
@@ -1,5 +1,53 @@
+# All these sections are optional, edit this file as you like.
+[general]
+# ignore=title-trailing-punctuation, T3
+ignore=B4
+# verbosity should be a value between 1 and 3, the commandline -v flags take precedence over this
+# verbosity = 2
+# By default gitlint will ignore merge commits. Set to 'false' to disable.
+# ignore-merge-commits=true
+# Enable debug mode (prints more output). Disabled by default.
+# debug=true
+
+# Set the extra-path where gitlint will search for user defined rules
+# See http://jorisroovers.github.io/gitlint/user_defined_rules for details
+# extra-path=examples/
+
 [title-max-length]
 line-length=72
 
+# [title-must-not-contain-word]
+# Comma-separated list of words that should not occur in the title. Matching is case
+# insensitive. It's fine if the keyword occurs as part of a larger word (so "WIPING"
+# will not cause a violation, but "WIP: my title" will.
+# words=wip
+
+# [title-match-regex]
+# python like regex (https://docs.python.org/2/library/re.html) that the
+# commit-msg title must be matched to.
+# Note that the regex can contradict with other rules if not used correctly
+# (e.g. title-must-not-contain-word).
+# regex=^US[0-9]*
+
+# [B1]
+# B1 = body-max-line-length
+# line-length=120
+
 [body-min-length]
 min-length=1
+
+# [body-is-missing]
+# Whether to ignore this rule on merge commits (which typically only have a title)
+# default = True
+# ignore-merge-commits=false
+
+# [body-changed-file-mention]
+# List of files that need to be explicitly mentioned in the body when they are changed
+# This is useful for when developers often erroneously edit certain files or git submodules.
+# By specifying this rule, developers can only change the file when they explicitly reference
+# it in the commit message.
+# files=gitlint/rules.py,README.md
+#
+
+~                                                                                                                                               
+~                                             


### PR DESCRIPTION
This patch adds a config rule to ignore the 2nd line space. This is not
an issue in our case due to the way CI runs the test (using content from
the patchwork API which doesn't include the title)