### PR TITLE
Add make check with valgrind option

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -82,6 +82,17 @@ submit_pw = yes
 
 
 ;
+; make check valgrind options
+;
+[makecheckvalgrind]
+; Enable makecheckvalgrind run. Default is 'yes' if it is not defined
+enable = yes
+; Enable submitting the result to patchwork page. Default is 'no' if it is not
+; defined
+submit_pw = yes
+
+
+;
 ; make distcheck options
 ;
 [makedistcheck]


### PR DESCRIPTION
This patch adds new test case to run make check with valgrind option is
enabled. Actually the valgrind option is enabled by disabling the lsan
and asan checking.