### PR TITLE
Don't send email if email config is disabled

### DIFF
--- a/run-ci.py
+++ b/run-ci.py
@@ -1301,8 +1301,13 @@ def report_ci():
 
     patch = pw_series['patches'][0]
 
-    # Compose email and send
-    compose_email(pw_series['name'], body, pw_series['submitter']['email'], patch['msgid'])
+    if config_enable(config, 'email'):
+        # Compose email and send
+        compose_email(pw_series['name'], body, pw_series['submitter']['email'],
+                      patch['msgid'])
+    else:
+        logger.info("Email is disabled. Skip sending email")
+        logger.debug("Message Body:\n%s" % body)
 
 def init_github(repo, pr_num):
     """


### PR DESCRIPTION
This patch checks the email configuration and don't send email if it is
not enabled.