### PR TITLE
entrypoint.sh: Add src and bluez path to git safe dir

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -35,6 +35,12 @@ if [[ -z $GITHUB_TOKEN ]]; then
 	exit 1
 fi
 
+echo "Add the source dir to GIT safe directory"
+git config --global --add safe.directory $SRC_PATH
+
+echo "Add the BlueZ source dir to GIT safe directory"
+git config --global --add safe.directory $BLUEZ_PATH
+
 echo "Clone ELL source"
 git clone --depth=1 https://git.kernel.org/pub/scm/libs/ell/ell.git $ELL_PATH
 


### PR DESCRIPTION
This patch adds src and bluez path to git safe dir in git.config.